### PR TITLE
Add the CD workflow to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,33 @@
+name: CD Pipeline
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /var/www/games-e-commerce
+
+            # Pull the latest changes from the main branch
+            git pull origin main
+
+            cd image_service
+            echo "${{ secrets.ENV_FILE_PROD_IMAGE_SERVICE }}" > .env
+            ./start-prod.sh
+
+            cd ../api_nest
+            echo "${{ secrets.ENV_FILE_PROD_API_NEST }}" > .env
+            ./start-prod.sh
+
+            cd ../frontend-next
+            echo "${{ secrets.ENV_FILE_PROD_FRONTEND_NEXT }}" > .env.production
+            ./start-prod.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI Pipeline
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: push
 
 jobs:
   api_nest:
@@ -19,7 +15,6 @@ jobs:
     env:
       MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
       MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
-      # MYSQL_USER: ${{ secrets.MYSQL_USER }}
       REDIS_HOST: ${{ secrets.REDIS_HOST }}
       REDIS_PORT: ${{ secrets.REDIS_PORT }}
       DATABASE_URL: ${{ secrets.CI_DATABASE_URL }}
@@ -33,6 +28,15 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+      
+      - name: Cache Bun dependencies
+        id: cache-bun
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: Start services with Docker Compose
         run: docker compose -f docker-compose.yml up -d --wait
@@ -43,6 +47,12 @@ jobs:
 
       - name: Install Dependencies
         run: bun install
+      
+      # - name: Run Linting
+      #   run: bun run lint
+      
+      - name: Build Project
+        run: bun run build
 
       - name: Generate Prisma Client
         run: bunx prisma migrate dev --schema=./src/models/prisma/schema.prisma
@@ -70,6 +80,9 @@ jobs:
 
       - name: Install Dependencies
         run: bun install
+      
+      # - name: Run Linting
+      #   run: bun run lint
 
       - name: Build Project
         run: bun run build
@@ -104,7 +117,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Start services with Docker Compose
-        run: docker compose -f docker-compose.yml up -d
+        run: docker compose -f docker-compose.yml up -d --wait
 
       - name: Cache uv dependencies
         id: cache-uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
       # - name: Run Linting
       #   run: bun run lint
       
-      - name: Build Project
-        run: bun run build
-
       - name: Generate Prisma Client
         run: bunx prisma migrate dev --schema=./src/models/prisma/schema.prisma
+      
+      - name: Build Project
+        run: bun run build
 
       - name: Run Tests
         run: bun run test

--- a/image_service/start-prod.sh
+++ b/image_service/start-prod.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Safely stop and remove old containers and volumes
+echo "Stopping existing containers..."
+docker compose -f docker-compose.yml -f docker-compose.prod.yml down
+docker volume rm next_static_volume || true
+
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+echo "Build and start completed successfully"

--- a/image_service/stop.sh
+++ b/image_service/stop.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+echo "Stopping all docker compose services"
+
+docker compose -f docker-compose.yml -f docker-compose.dev.yml down
+docker compose -f docker-compose.yml -f docker-compose.prod.yml down --remove-orphans
+
+echo "All services stopped successfully"


### PR DESCRIPTION
This pull request introduces a new CD pipeline for automated deployment and improves the CI pipeline for efficiency and reliability. It also adds scripts for managing production and development Docker services in the `image_service` module.

**CI/CD Pipeline Enhancements**

* Added a new GitHub Actions workflow `.github/workflows/cd.yml` to automate deployment to EC2 on pull requests to the `main` branch, including environment setup and service startup for `image_service`, `api_nest`, and `frontend-next` (`[.github/workflows/cd.ymlR1-R33](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R1-R33)`).
* Updated the CI workflow in `.github/workflows/ci.yml` to trigger only on push events, streamlining pipeline execution (`[.github/workflows/ci.ymlL3-R3](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL3-R3)`).
* Improved dependency management in the CI pipeline by caching Bun dependencies for faster builds (`[.github/workflows/ci.ymlR32-R40](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR32-R40)`).
* Added build steps to CI for both `api_nest` and `frontend-next` jobs to ensure artifacts are ready before testing (`[[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR51-R59)`, `[[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR84-R86)`).
* Changed Docker Compose commands in CI to use the `--wait` flag, enhancing reliability by waiting for services to be ready before proceeding (`[.github/workflows/ci.ymlL107-R120](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL107-R120)`).

**Service Management Scripts**

* Added `image_service/start-prod.sh` to safely stop old containers/volumes and build/start production services with Docker Compose (`[image_service/start-prod.shR1-R12](diffhunk://#diff-1b5ba6f9a9f953ee5b274c886c152709e13f06a9d8fd9445c240f191303a2a28R1-R12)`).
* Added `image_service/stop.sh` for stopping all development and production Docker Compose services, including orphan removal for cleanup (`[image_service/stop.shR1-R10](diffhunk://#diff-fdab2e92e76ec62aca5bc68b95aadc4e905f9fb0c63c52a0a8bef130a66fb0daR1-R10)`).