### PR TITLE
Include chmod for the scripts and change Home page text

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,12 +28,15 @@ jobs:
 
             cd image_service
             echo "${{ secrets.ENV_FILE_PROD_IMAGE_SERVICE }}" > .env
+            chmod +x start-prod.sh
             ./start-prod.sh
 
             cd ../api_nest
             echo "${{ secrets.ENV_FILE_PROD_API_NEST }}" > .env
+            chmod +x start-prod.sh
             ./start-prod.sh
 
             cd ../frontend-next
             echo "${{ secrets.ENV_FILE_PROD_FRONTEND_NEXT }}" > .env.production
+            chmod +x start-prod.sh
             ./start-prod.sh

--- a/frontend-next/app/page.test.tsx
+++ b/frontend-next/app/page.test.tsx
@@ -42,7 +42,7 @@ describe("Home Page", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: /discover, buy, and play thousands of games/i,
+        name: /discover and play thousands of games/i,
       }),
     ).toBeInTheDocument();
     expect(

--- a/frontend-next/app/page.tsx
+++ b/frontend-next/app/page.tsx
@@ -17,7 +17,7 @@ export default async function Home() {
           />
         </div>
         <h2 className="my-20 text-center md:text-4xl lg:text-5xl">
-          Discover, buy, and play thousands of games
+          Discover and play thousands of games
         </h2>
         <section className="grid grid-cols-1 gap-8 bg-[#393E46] p-5 text-[#DFD0B8] lg:grid-cols-3">
           {games.games.map((game) => (


### PR DESCRIPTION
This pull request includes minor updates to both deployment scripts and the home page text for consistency and improved user experience.

Deployment script adjustments:

* Added `chmod +x start-prod.sh` before running the production startup script in `image_service`, `api_nest`, and `frontend-next` services in `.github/workflows/cd.yml` to ensure the script is executable during deployment.

Home page text consistency:

* Updated the main heading in `frontend-next/app/page.tsx` and its corresponding test in `frontend-next/app/page.test.tsx` to remove "buy" from the phrase, changing it to "Discover and play thousands of games" for a more accurate description. [[1]](diffhunk://#diff-0fc6e83becfd4114d8775be623795899378e295140a126819444a9530b4d1214L20-R20) [[2]](diffhunk://#diff-565c5b149f20100f928d55c58508923f6de58be6df29761370d4cea4fa5a42adL45-R45)