### PR TITLE
Create a prefix route for routing from frontend to backend using proxy reverse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI Pipeline
 
-on: 
-  push:
-  pull_request:
-    branches: [main]
+on: push
 
 jobs:
   api_nest:

--- a/api_nest/src/main.ts
+++ b/api_nest/src/main.ts
@@ -6,6 +6,7 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.setGlobalPrefix('api');
   app.useLogger(new Logger('NestApplication', { timestamp: true }));
   app.useGlobalFilters(new HttpExceptionFilter());
   app.enableCors();

--- a/frontend-next/.env.example
+++ b/frontend-next/.env.example
@@ -18,7 +18,7 @@ AUTH_SECRET="your-super-secret-key-here"
 INTERNAL_API_URL=http://app:3001
 
 # This is for the browser (client-side)
-NEXT_PUBLIC_API_URL=http://<your-ec2-ip>:3001
+NEXT_PUBLIC_API_URL=/api
 NEXTAUTH_URL=http://<your-ec2-ip>:80
 
 AUTH_SECRET="your-super-secret-key-here"

--- a/frontend-next/nginx.conf
+++ b/frontend-next/nginx.conf
@@ -17,6 +17,15 @@ http {
             access_log off;
         }
 
+        # Single location block for ALL backend traffic
+        location /api {
+            proxy_pass http://app:3001;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location / {
             expires -1;
             proxy_pass http://frontend:3000;


### PR DESCRIPTION
This pull request standardizes API routing across the frontend and backend, improves configuration for deployment, and simplifies the CI workflow trigger. The main changes ensure that all backend API traffic is routed through `/api`, both in the frontend and via Nginx, and that the backend application recognizes this prefix. Additionally, the CI pipeline is now triggered only on push events.

**API Routing Standardization:**

* Added a single Nginx location block to route all `/api` requests to the backend (`app:3001`), ensuring consistent API traffic handling.
* Set the global API prefix to `/api` in the NestJS backend by adding `app.setGlobalPrefix('api')` in `main.ts`.

**Frontend Configuration Updates:**

* Changed `NEXT_PUBLIC_API_URL` in `.env.example` to `/api`, aligning frontend API calls with the new routing pattern.

**CI Workflow Simplification:**

* Updated the CI pipeline trigger in `.github/workflows/ci.yml` to run only on push events, removing the pull request trigger for the `main` branch.