### PR TITLE
Update CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,21 +17,23 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
+            PARENT_DIR="/var/www"
             PROJECT_DIR="/var/www/games-e-commerce"
+
+            sudo mkdir -p $PARENT_DIR
+            sudo chown -R $USER:$USER $PARENT_DIR
 
             # Check if the project directory exists
             if [ -d "$PROJECT_DIR" ]; then
               echo "Project directory exists. Pulling latest changes."
               cd $PROJECT_DIR
               git config --global --add safe.directory $PROJECT_DIR
-              sudo chown -R ubuntu:ubuntu .
               git pull origin main
             else
               echo "Project directory does not exist. Cloning repository."
               # Make sure to replace the URL with your repository's URL
               git clone https://github.com/RoberthParreiras/games-e-commerce.git $PROJECT_DIR
               cd $PROJECT_DIR
-              sudo chown -R ubuntu:ubuntu .
             fi
 
             cd image_service


### PR DESCRIPTION
This pull request updates the deployment script in `.github/workflows/cd.yml` to improve directory handling and user permissions during the deployment process. The changes ensure the parent directory exists and is correctly owned before proceeding with git operations.

Deployment script improvements:

* Added commands to create the parent directory (`/var/www`) if it doesn't exist and set its ownership to the current user, ensuring proper permissions for subsequent operations.
* Removed redundant `chown` commands that previously set ownership to `ubuntu:ubuntu` after pulling or cloning the repository, as ownership is now set at the parent directory level.